### PR TITLE
Improve error message when cram index file is not found

### DIFF
--- a/client/js/bam.iobio.js/bam.iobio.js
+++ b/client/js/bam.iobio.js/bam.iobio.js
@@ -200,7 +200,7 @@ var Bam = Class.extend({
         if (!this.hadError) {
           alert("Error accessing the BAM index file. Please provide an " +
                 "index file URL or ensure that " +
-                `${this.bamUri + '.bai'} exists`);
+                `${indexUrl} exists`);
           baiErrCb(e);
         }
         console.log(e);


### PR DESCRIPTION
Improve the error message by using index URL instead of `${this.bamUri + '.bai'}`.

This is useful when user gives a cram file. it will display XXXX.cram.crai instead of XXXX.cram.bai